### PR TITLE
Wichserb 31 july speed up search

### DIFF
--- a/server/function.js
+++ b/server/function.js
@@ -273,19 +273,19 @@ function itemSearchAddPrice(params, body) {
    *  body (object): Body of search request
    * Returns:
    *  Nothing.  Alters `params`
-   */ 
+   */
   if ('minPrice' in body && 'maxPrice' in body) {
-    params.FilterExpression += "price between :minPrice and :maxPrice"; 
-    params.ExpressionAttributeValues[':minPrice'] = {'N': Number(body.minPrice)};
-    params.ExpressionAttributeValues[':maxPrice'] = {'N': Number(body.maxPrice)};
+    params.FilterExpression += "AND price between :minPrice and :maxPrice"; 
+    params.ExpressionAttributeValues[':minPrice'] = {'N': String(body.minPrice)};
+    params.ExpressionAttributeValues[':maxPrice'] = {'N': String(body.maxPrice)};
   } else if ('minPrice' in body)
   {
-    params.FilterExpression += "price >= :minPrice";
-    params.ExpressionAttributeValues[':minPrice'] = {'N': Number(body.minPrice)};
+    params.FilterExpression += "AND price >= :minPrice";
+    params.ExpressionAttributeValues[':minPrice'] = {'N': String(body.minPrice)};
   } else if ('maxPrice' in body)
   {
-    params.FilterExpression += "price <= :maxPrice";
-    params.ExpressionAttributeValues[':maxPrice'] = {'N': Number(body.maxPrice)};
+    params.FilterExpression += "AND price <= :maxPrice";
+    params.ExpressionAttributeValues[':maxPrice'] = {'N': String(body.maxPrice)};
   }
  }
 

--- a/server/function.js
+++ b/server/function.js
@@ -236,7 +236,7 @@ function itemSearchAddLocation(params, body, zipController) {
   // set default location to home of PBS's "Zoom" if there is none already given
   var zip = 'location' in body ? String(body.location) : '70116';
   // set default distance to 5 miles
-  var radius = 'radius' in body ? Number(body.radius) : 1100;
+  var radius = 'radius' in body ? Number(body.radius) : 5;
   const goodZips = zipcodes.radius(zip, radius);
   // if, for some crazy reason, we have no zip codes...bail
   if (goodZips.length == 0)

--- a/server/routes/items.js
+++ b/server/routes/items.js
@@ -43,7 +43,7 @@ router.get("/", async (req, res) => {
     console.log("Got listings.  Now going to clean them up")
     res.status(201).json(db.makeListingsOutput(listings));
   } catch (err) {
-    console.log(`Error getting item list: ${err}`);
+    console.log(`ERROR getting item list: ${err}`);
   }
 });
 


### PR DESCRIPTION
Once again, the branch name is somewhat misleading.  Search is sped up, but it also now accepts price (min and max, default at none for each), distance to user (default at 5 miles), and a search term (default at an empty string).  Empty searches return all items within the other parameters.  Non-empty searches require at least one hit among the tags list.

Return object contains both distance to user and a relevance (count of tag hits to search words).    Minimally tested at this point.