### PR TITLE
Wichserb 4 august personalize empty searches

### DIFF
--- a/server/dbStructure.js
+++ b/server/dbStructure.js
@@ -10,7 +10,7 @@ const userTemplate = {
     'items_bought': 'L',        // [ {'S': id }, ]
     'current_listings': 'L',    // [ {'S': id }, ]
     'past_listings': 'L',       // [ {'S': id }, ]
-    'recent_searches': 'L'      // [ {'M': {'search': 'S', 'most_recent_search': S}}, ]
+    'recent_searches': 'L'      // [ { 'S': recent_tag}, {'S'}: other_recent_tag}, ]
 }
 
 const itemTemplate = {

--- a/server/function.js
+++ b/server/function.js
@@ -393,7 +393,10 @@ async function itemSearchAddTags(params, body, needSuggestions = false){
       console.log(getTagsParams);
       var suggestedTags = await ddbClient.send(new QueryCommand(getTagsParams));
       console.log(suggestedTags);
-      suggestedTags = suggestedTags.Items[0].recent_searches.L;
+      suggestedTags = 'recent_searches' in suggestedTags.Items[0] && 
+          'L' in suggestedTags.Items[0].recent_searches ?
+        suggestedTags.Items[0].recent_searches.L :
+        [];
       console.log(suggestedTags);
       // turn return into list of just strings
       suggestedTags.forEach( (item, index) => {
@@ -634,6 +637,7 @@ function itemPostTagEnhancer(body) {
   *   Null.  Alters `body['tags']`.
   */
  // make new array based on any tags already there
+ console.log(body);
   let improvedTags = body.hasOwnProperty('tags') ? body['tags'] : [];
   // remove punctuation from both title and tags, in that order -- 
   // Not entirely sure ALL punctuation removal is best

--- a/server/function.js
+++ b/server/function.js
@@ -271,7 +271,6 @@ async function saveUserSearchTerms(body) {
         searchHistory.shift();
       searchHistory.push({'S': searchTag});
     }
-    console.log(`User ${body.user_id}'s new search history: ${searchHistory}`);
    } catch (err) {
     console.log(`ERROR saveUserSearchTerms -- Error getting search history for user ${body.user_id}: ${err}`);
   }
@@ -549,7 +548,6 @@ async function getItemSuggestions(body) {
       returnItems = returnItems.concat(newItems['Items']);
     }
   }
-console.log(`Suggested Items: \n ${returnItems}`)
 return returnItems;
 }  
     

--- a/server/routes/items.js
+++ b/server/routes/items.js
@@ -39,7 +39,11 @@ router.post(
 
 router.get("/", async (req, res) => {
   try {
+    // log incoming search
     console.log(JSON.stringify(req.query));
+    // save any search terms to user's record
+    db.saveUserSearchTerms(req.query);
+    // get search results
     let listings = await db.getItemList(req.query);
     res.status(201).json(db.makeListingsOutput(listings));
   } catch (err) {

--- a/server/routes/items.js
+++ b/server/routes/items.js
@@ -39,8 +39,6 @@ router.post(
 
 router.get("/", async (req, res) => {
   try {
-    // log incoming search
-    console.log(JSON.stringify(req.query));
     // save any search terms to user's record
     db.saveUserSearchTerms(req.query);
     // get search results

--- a/server/samples/sample_items.js
+++ b/server/samples/sample_items.js
@@ -239,6 +239,47 @@ const sampleItemK = {
     ]
 }
 
+const sampleItemL = {
+    // item that is close ot jbutt and has specific tags for testing
+    id: 'sampleItemL',
+    date_added: String( Date.now()),
+    title: 'Sparkly item',
+    description: 'Item meant to hit tags: sparkly, bedazzle, pink, unicorn, item.',
+    seller_id: 'neighborSeller',
+    location: '70146',
+    status: 'For Sale',
+    price: '2.3',
+    photos: [],
+    tags: [
+        {'S': 'sparkly'},
+        {'S': 'bedazzle'},
+        {'S': 'pink'},
+        {'S': 'unicorn'},
+        {'S': 'item'}
+    ]
+}
+
+const sampleItemM = {
+    // item that is close to jbutt and has specific tags for testing
+    id: 'sampleItemM',
+    date_added: String( Date.now()),
+    title: 'Boring item',
+    description: 'Item mean to hit tags: boring, gray, grey, dull, item.',
+    seller_id: 'neighborSeller',
+    location: '70146',
+    status: 'For Sale',
+    price: '1.234',
+    photos: [],
+    tags: [
+        {'S': 'boring'},
+        {'S': 'gray'},
+        {'S': 'grey'},
+        {'S': 'dull'},
+        {'S': 'item'}
+    ]
+}
+
+
 const sampleItems = [
     sampleItemA,
     sampleItemB,
@@ -250,6 +291,8 @@ const sampleItems = [
     sampleItemH,
     sampleItemI,
     sampleItemJ,
-    sampleItemK
+    sampleItemK,
+    sampleItemL,
+    sampleItemM
 ]
 module.exports = {sampleItems};


### PR DESCRIPTION
Searches sent without any string in the "tags" field now return personalized results based on past search history, along with other results based on non-tag search criteria (price, location).

Searches sent with a string in the "tags" field now save cleaned-up version of the words in search string to search history, and return results based on search string only.

Note: more testing may be necessary.  Tested minimally in browser, but browser pre-caching may have altered search history somewhat.